### PR TITLE
Alphabetize blocks

### DIFF
--- a/nio_cli/commands/buildspec.py
+++ b/nio_cli/commands/buildspec.py
@@ -29,7 +29,7 @@ class BuildSpec(Base):
         merged_spec = self._merge_previous_into_new_spec(previous_spec, spec)
         sorted_spec = self._order_dict(merged_spec)
         with open(file_path, 'w') as f:
-            json.dump(sorted_spec, f, indent=2)
+            json.dump(sorted_spec, f, indent=2, sort_keys=True)
 
     def _read_spec(self, file_path):
         if os.path.exists(file_path):
@@ -73,7 +73,7 @@ class BuildSpec(Base):
                     key=lambda i: keyorder.index(i[0])
                 ))
             self._alphabetical_order_dict(spec[block])
-        return OrderedDict(sorted(spec.items(), key=lambda i: i[0]))
+        return spec
 
     @staticmethod
     def _alphabetical_order_dict(dict):

--- a/nio_cli/commands/buildspec.py
+++ b/nio_cli/commands/buildspec.py
@@ -72,7 +72,7 @@ class BuildSpec(Base):
                     key=lambda i: keyorder.index(i[0])
                 ))
             self._alphabetical_order_dict(spec[block])
-        return spec
+        return OrderedDict(sorted(spec.items(), key=lambda i: i[0]))
 
     @staticmethod
     def _alphabetical_order_dict(dict):

--- a/nio_cli/commands/buildspec.py
+++ b/nio_cli/commands/buildspec.py
@@ -29,7 +29,7 @@ class BuildSpec(Base):
         merged_spec = self._merge_previous_into_new_spec(previous_spec, spec)
         sorted_spec = self._order_dict(merged_spec)
         with open(file_path, 'w') as f:
-            json.dump(sorted_spec, f, indent=2, sort_keys=True)
+            json.dump(sorted_spec, f, indent=2)
 
     def _read_spec(self, file_path):
         if os.path.exists(file_path):
@@ -73,7 +73,7 @@ class BuildSpec(Base):
                     key=lambda i: keyorder.index(i[0])
                 ))
             self._alphabetical_order_dict(spec[block])
-        return spec
+        return OrderedDict(sorted(spec.items(), key=lambda i: i[0]))
 
     @staticmethod
     def _alphabetical_order_dict(dict):
@@ -81,7 +81,7 @@ class BuildSpec(Base):
             dict[key] = OrderedDict(
                 sorted(dict[key].items(), key=lambda  i: i[0]))
         for prop_key in dict["properties"]:
-            keyorder = ["title", "description", "default"]
+            keyorder = ["title", "type", "description", "default"]
             dict["properties"][prop_key] = OrderedDict(
                 sorted(
                     dict["properties"][prop_key].items(),
@@ -101,10 +101,11 @@ class BuildSpec(Base):
         properties_spec = {}
         properties = block.get_description()["properties"]
         for k, property in properties.items():
-            if k in ['type', 'name', 'version', 'log_level']:
+            if k in ["type", "name", "version", "log_level"]:
                 continue
             property_spec = {}
-            property_spec["title"] = property['title']
+            property_spec["title"] = property["title"]
+            property_spec["type"] = property["type"]
             if "default" in property:
                 property_spec["default"] = property["default"]
             properties_spec[k] = property_spec

--- a/nio_cli/commands/buildspec.py
+++ b/nio_cli/commands/buildspec.py
@@ -40,8 +40,9 @@ class BuildSpec(Base):
 
     def _merge_previous_into_new_spec(self, previous_spec, spec):
         for block in spec:
-            manual_fields = [("description", ""), ("outputs", {}),
-                             ("inputs", {})]
+            manual_fields = [("description", ""),
+                             ("outputs", {"default": {"description": ""}}),
+                             ("inputs", {"default": {"description": ""}})]
             for field in manual_fields:
                 spec[block][field[0]] = \
                     previous_spec.get(block, {}).get(field[0], field[1])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -183,8 +183,16 @@ class TestCLI(unittest.TestCase):
                 "nio/SampleBlock1": {
                     "version": "0.1.0",
                     "description": "",
-                    "outputs": {},
-                    "inputs": {},
+                    "outputs": {
+                        "default": {
+                            "description": ""
+                        }
+                    },
+                    "inputs": {
+                        "default": {
+                            "description": ""
+                        }
+                    },
                     "properties": {
                         "another": {
                             "description": "",
@@ -205,8 +213,16 @@ class TestCLI(unittest.TestCase):
                 "nio/SampleBlock2": {
                     "version": "0.0.0",
                     "description": "",
-                    "outputs": {},
-                    "inputs": {},
+                    "outputs": {
+                        "default": {
+                            "description": ""
+                        }
+                    },
+                    "inputs": {
+                        "default": {
+                            "description": ""
+                        }
+                    },
                     "properties": {},
                     "commands": {},
                 },

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -196,11 +196,13 @@ class TestCLI(unittest.TestCase):
                     "properties": {
                         "another": {
                             "description": "",
+                            "type": "StringType",
                             "title": "Another Prop",
                             "default": None
                         },
                         "str_prop": {
                             "title": "String Prop",
+                            "type": "StringType",
                             "default": "default string",
                             "description": "",
                         }


### PR DESCRIPTION
Reverted back to not sort via json.dump's sort feature; the sort feature was also overriding the specified sort order of the other `OrderedDict`s